### PR TITLE
Harden crash supervisor backend and normalize termination capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,35 @@
+const std = @import("std");
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+
+    const exe = b.addExecutable(.{
+        .name = "zigprofiler",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    b.installArtifact(exe);
+
+    const run_cmd = b.addRunArtifact(exe);
+    if (b.args) |args| run_cmd.addArgs(args);
+
+    const run_step = b.step("run", "Run zigprofiler");
+    run_step.dependOn(&run_cmd.step);
+
+    const exe_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const run_unit_tests = b.addRunArtifact(exe_unit_tests);
+    const test_step = b.step("test", "Run unit tests");
+    test_step.dependOn(&run_unit_tests.step);
+}

--- a/draft.md
+++ b/draft.md
@@ -1,234 +1,412 @@
-# zigprofiler — Agent-first Zig profiler & debugger
+# zigprofiler
 
-## Problem
+An agent-first profiler and debugging toolkit for Zig.
 
-Profiling Zig code today is painful:
-- `perf` and `Instruments.app` work but give assembly-level output — hard to map back to Zig source
-- No built-in memory profiler — `GeneralPurposeAllocator` tracks leaks but not allocation patterns
-- Segfaults in Zig give a stack trace but no context (what values, what state)
-- No tool understands Zig's comptime, error unions, or optional types natively
-- Profiling Zig→Python C extensions (like our faster-boto3/faster-redis) is especially hard — the call stack crosses language boundaries
+## One-liner
 
-## Vision
+`zigprofiler` is a CLI for answering the questions Zig developers actually have when performance or crashes go sideways:
 
-A **CLI profiler built for Zig developers** that's also **agent-friendly** (structured output, machine-parseable, composable with Claude Code / AI agents).
+- Where is time going in this binary?
+- Which allocator paths are creating churn or leaks?
+- Why did this process crash, and what was the likely Zig-level cause?
+- Did this change make the program faster or slower?
 
+Existing tooling can often collect low-level signals. The gap is interpretation. Zig developers still end up translating raw stacks, symbols, allocator events, and crash dumps back into source-level intent by hand. `zigprofiler` exists to close that gap.
+
+That applies to crashes too: a fault report should still be useful even if the user never collected a profile beforehand.
+
+## Thesis
+
+General-purpose profilers are built for systems code in the abstract. `zigprofiler` is built for Zig code specifically.
+
+That means:
+
+- Source-level output that points back to Zig files, functions, and lines instead of dumping opaque runtime frames.
+- Tooling that understands Zig patterns such as allocators, error unions, optionals, slices, and cross-language C boundaries.
+- Structured output that AI agents, CI systems, and custom dashboards can consume directly.
+
+The goal is not to replace `perf`, Instruments, Valgrind, or Tracy at the kernel/runtime layer. The goal is to sit above them when needed, integrate with platform-specific collection mechanisms, and present results in a form that is useful to Zig developers immediately.
+
+## The Problem
+
+Profiling and debugging Zig code today is still too fragmented.
+
+- CPU profiling often drops you into assembly-heavy or C-oriented stacks that are tedious to map back to Zig code.
+- Memory investigation is split between allocator-specific instrumentation, leak detection, and ad hoc logging.
+- Crash analysis gives you a stack trace, but not a focused explanation of likely Zig-level failure modes.
+- Cross-language code paths, especially Zig called from Python or other runtimes through C ABI boundaries, are hard to reason about end to end.
+- None of the above tools are designed to produce deterministic, machine-parseable summaries for agent workflows.
+
+This is especially painful for teams shipping high-performance Zig libraries, CLIs, servers, or language bindings. The data may exist, but the human still has to perform the synthesis.
+
+## Product Goal
+
+Build a single CLI that can do four jobs well:
+
+1. Profile CPU time in a Zig-aware way.
+2. Track allocator behavior and memory pressure.
+3. Turn faults into actionable crash reports.
+4. Compare benchmark and profile outputs over time.
+
+If the tool cannot make the first debugging or optimization decision easier, it is not finished.
+
+## Non-goals
+
+`zigprofiler` should not try to become:
+
+- A full interactive debugger replacement for LLDB or GDB.
+- A full tracing platform with distributed systems concerns.
+- A giant GUI application.
+- A generic profiler for every language under the sun in v1.
+
+The right shape is a sharp CLI with excellent textual and JSON output, plus optional visualization artifacts like flamegraphs.
+
+## User Experience
+
+The interface should feel obvious:
+
+```bash
+zigprofiler run ./zig-out/bin/app
+zigprofiler mem ./zig-out/bin/app
+zigprofiler crash ./zig-out/bin/app
+zigprofiler bench ./zig-out/bin/app
+zigprofiler diff baseline.json candidate.json
 ```
-zigprofiler run ./my-program          # CPU profile + flamegraph
-zigprofiler mem ./my-program          # allocation tracking
-zigprofiler segfault ./my-program     # catch + analyze segfaults
-zigprofiler bench ./my-program        # micro-benchmark with stats
-zigprofiler diff old.profile new.profile  # regression detection
-```
 
-## Core Features
+Every command should support:
 
-### 1. CPU Profiler (`zigprofiler run`)
+- Human-readable terminal output by default.
+- `--json` for machine consumption.
+- Stable exit codes for CI and agent workflows.
+- Clear separation between collection, analysis, and rendering.
 
-- Sampling profiler using `SIGPROF` / Instruments
-- **Zig-aware**: maps addresses back to Zig source lines, shows function names (not mangled)
-- **Scope-aware**: groups by Zig function, shows time per scope
-- **Flamegraph output**: SVG + JSON for visualization
-- **Agent mode**: `--json` output for AI agents to analyze
+## Core Commands
 
-```
-zigprofiler run --json ./my-program
+### `zigprofiler run`
+
+CPU profiler for answering “where is time going?”
+
+Target output:
+
+- Top functions by self time and total time.
+- Hot lines and scopes in Zig source.
+- Call stacks suitable for flamegraph generation.
+- Optional comparison against a previous profile.
+
+Example:
+
+```json
 {
-  "total_time_us": 1234567,
+  "kind": "cpu_profile",
+  "binary": "./zig-out/bin/app",
+  "duration_ms": 2000,
+  "samples": 48122,
   "functions": [
-    {"name": "resp.parse", "file": "src/resp.zig", "line": 42, "self_us": 45000, "total_us": 89000, "calls": 500000},
-    {"name": "resp.findCRLF", "file": "src/resp.zig", "line": 15, "self_us": 32000, "total_us": 32000, "calls": 1500000}
+    {
+      "name": "resp.parse",
+      "file": "src/resp.zig",
+      "line": 42,
+      "self_pct": 18.2,
+      "total_pct": 31.4,
+      "samples": 8758
+    },
+    {
+      "name": "resp.findCRLF",
+      "file": "src/resp.zig",
+      "line": 15,
+      "self_pct": 12.7,
+      "total_pct": 12.7,
+      "samples": 6112
+    }
   ],
   "hotspots": [
-    {"file": "src/resp.zig", "line": 28, "instruction": "simd_compare", "us": 12000, "pct": 0.97}
+    {
+      "file": "src/resp.zig",
+      "line": 28,
+      "label": "simd compare loop",
+      "self_pct": 7.1
+    }
   ]
 }
 ```
 
-### 2. Memory Profiler (`zigprofiler mem`)
+### `zigprofiler mem`
 
-- Wraps Zig allocators to track every allocation/free
-- **Live dashboard**: shows heap size, allocation rate, largest live objects
-- **Leak detection**: with source location of the leak
-- **Allocation flamegraph**: where memory is allocated from
-- **Peak tracking**: max heap size and what caused it
+Allocator-aware memory profiler for answering “what is allocating, growing, or leaking?”
 
-```
-zigprofiler mem ./my-program
-Peak heap: 4.2MB at t=1.3s
-  2.1MB — resp.zig:parseArray (allocator.alloc)
-  1.8MB — client.zig:readResponse (read_buf)
-  0.3MB — main.zig:py_parse_resp (c_allocator)
+Target output:
 
-Leaked: 0 bytes (clean)
-Allocations: 1,234,567 total (345MB throughput)
-  Hot: resp.zig:parseArray — 800K allocs (avg 2.6KB)
-```
+- Current heap size and peak heap size.
+- Allocation throughput and count.
+- Largest live allocation sites.
+- Leak summary by Zig source location.
+- Allocation call stacks suitable for flamegraph generation.
 
-### 3. Segfault Analyzer (`zigprofiler segfault`)
+Example:
 
-- Catches SIGSEGV/SIGBUS and produces a rich report
-- **Register dump**: with Zig variable names mapped to registers
-- **Stack unwinding**: full Zig stack trace with source lines
-- **Memory map**: shows what's near the faulting address
-- **Root cause hints**: "null pointer dereference on optional", "slice out of bounds", "use-after-free"
+```text
+Peak heap: 4.2 MiB at 1.3s
+Live allocations: 1,842
+Throughput: 345 MiB across 1,234,567 allocs
 
-```
-zigprofiler segfault ./my-program
-SEGFAULT at 0x0000000000000008 (null + 8)
+Top live sites
+  2.1 MiB  src/resp.zig:88   parseArray
+  1.8 MiB  src/client.zig:54 readResponse
+  0.3 MiB  src/main.zig:21   py_parse_resp
 
-Likely cause: null optional dereference
-  → self.stream.?.write(data)
-  → self.stream is null
-
-Stack:
-  client.zig:92  RedisClient.send
-  client.zig:57  RedisClient.command
-  main.zig:78    py_command
-
-Registers:
-  x0 = 0x0000000000000000 (null — this is `self.stream`)
-  x1 = 0x000000016fdfc000 (stack — `data` slice ptr)
+Leaks
+  clean
 ```
 
-### 4. Micro-benchmark (`zigprofiler bench`)
+### `zigprofiler crash`
 
-- Built-in benchmarking with statistical rigor
-- **Warmup detection**: auto-detects when JIT/cache is warm
-- **Outlier removal**: trims top/bottom percentiles
-- **Comparison mode**: A/B two builds side-by-side
-- **Regression detection**: fails CI if perf regresses
+Crash and fault analyzer for answering “why did this die?”
 
+Target output:
+
+- Standalone post-mortem analysis, even when no prior profile exists.
+- Fault signal and address.
+- Symbolized stack trace.
+- Register dump with context where possible.
+- Nearby memory mapping information.
+- Heuristic hints for likely Zig-level causes such as null optional dereference, bounds violation, invalid enum tag, or use-after-free.
+
+Example:
+
+```text
+SIGSEGV at 0x0000000000000008
+
+Likely cause
+  null optional dereference
+  expression: self.stream.?.write(data)
+
+Stack
+  src/client.zig:92 RedisClient.send
+  src/client.zig:57 RedisClient.command
+  src/main.zig:78   py_command
+
+Registers
+  x0 = 0x0000000000000000  self.stream
+  x1 = 0x000000016fdfc000  data.ptr
 ```
-zigprofiler bench --compare old_binary new_binary
-                    old          new       change
-parse_simple     58ns ±2%     52ns ±1%    -10.3% (p=0.001)
-parse_bulk       61ns ±3%     55ns ±2%     -9.8% (p=0.002)
-pack_SET        104ns ±1%    101ns ±1%     -2.9% (p=0.04)
 
-VERDICT: 2 significant improvements, 0 regressions
+### `zigprofiler bench`
+
+Benchmark runner for answering “did this get faster, and is the result statistically credible?”
+
+Target output:
+
+- Warmup handling.
+- Repeated measurements with confidence intervals.
+- Outlier trimming or robust statistics.
+- Baseline comparison mode.
+- CI-friendly regression thresholds.
+
+Example:
+
+```text
+Benchmark            old            new            delta
+parse_simple         58 ns ±2%      52 ns ±1%      -10.3%
+parse_bulk           61 ns ±3%      55 ns ±2%       -9.8%
+pack_SET            104 ns ±1%     101 ns ±1%       -2.9%
+
+Verdict: 2 wins, 0 regressions
 ```
 
-### 5. Cross-language profiler (`zigprofiler ffi`)
+### `zigprofiler diff`
 
-- Profiles Zig code called from Python via C extension
-- **Unified flamegraph**: Python frames + Zig frames in one view
-- **Boundary markers**: shows where Python→Zig transition happens
-- **GIL tracking**: shows when GIL is held vs released
+Comparison engine for profile and benchmark artifacts.
 
-```
-zigprofiler ffi python my_script.py
-  Python: my_script.py:10 — parse_resp()         2.3us
-    → [C boundary: PyArg_ParseTuple]              0.1us
-    → Zig: main.zig:15 — py_parse_resp()          0.05us
-      → Zig: resp.zig:42 — parse()                0.03us
-        → Zig: resp.zig:15 — findCRLF() [SIMD]    0.02us
-    → [C boundary: PyUnicode_FromStringAndSize]    0.08us
-  Python: return value                             0.01us
-```
+This command matters because “collecting data” is only half the job. Teams need to compare current behavior against a known baseline and make the change legible.
+
+Target output:
+
+- Regressed functions or benchmarks.
+- New hotspots introduced by a change.
+- Reduced or increased allocation pressure.
+- Summary suitable for PR comments or CI annotations.
+
+## Agent-first by design
+
+This tool should be excellent for humans and excellent for agents.
+
+That means every command should emit structured output that is:
+
+- Stable enough to script against.
+- Rich enough to support automated diagnosis.
+- Compact enough to feed into an LLM without burying the useful signal.
+
+That includes crash-only workflows, where the agent is reasoning from a fault report or crash artifact rather than from a collected performance profile.
+
+Example workflow:
+
+1. An agent runs `zigprofiler run --json ./zig-out/bin/tests`.
+2. It identifies that `findCRLF` dominates self time in short-buffer workloads.
+3. It runs `zigprofiler bench --json --function findCRLF`.
+4. It concludes that the SIMD path only helps above a certain buffer length.
+5. It recommends a short-input scalar fast path.
+6. The user applies the change and reruns `zigprofiler diff`.
+
+That is the product: not just measurement, but fast synthesis.
 
 ## Architecture
 
-```
-zigprofiler (CLI)
-├── cmd/          — CLI commands (run, mem, segfault, bench, diff, ffi)
-├── core/
-│   ├── sampler.zig     — SIGPROF-based CPU sampling
-│   ├── allocator.zig   — Wrapping allocator for memory tracking
-│   ├── unwinder.zig    — Stack unwinder using DWARF debug info
-│   ├── symbolizer.zig  — Address → Zig source line mapping
-│   ├── segfault.zig    — SIGSEGV handler + analysis
-│   └── stats.zig       — Statistical analysis (mean, stdev, t-test)
-├── output/
-│   ├── json.zig        — Structured JSON output (agent-friendly)
-│   ├── flamegraph.zig  — SVG flamegraph generator
-│   ├── terminal.zig    — Rich terminal output (colors, tables)
-│   └── diff.zig        — Profile comparison + regression detection
-├── ffi/
-│   ├── python.zig      — Python frame detection
-│   ├── boundary.zig    — Language boundary tracking
-│   └── gil.zig         — GIL state tracking
+The implementation should be modular and brutally practical.
+
+```text
+zigprofiler/
+├── src/
+│   ├── main.zig
+│   ├── cmd/
+│   │   ├── run.zig
+│   │   ├── mem.zig
+│   │   ├── crash.zig
+│   │   ├── bench.zig
+│   │   └── diff.zig
+│   ├── core/
+│   │   ├── sampler.zig
+│   │   ├── allocator_trace.zig
+│   │   ├── symbolizer.zig
+│   │   ├── dwarf.zig
+│   │   ├── crash_analyzer.zig
+│   │   └── stats.zig
+│   ├── render/
+│   │   ├── terminal.zig
+│   │   ├── json.zig
+│   │   └── flamegraph.zig
+│   └── platform/
+│       ├── linux.zig
+│       └── macos.zig
 └── build.zig
 ```
 
-## Agent-First Design
+Key design choices:
 
-Every command supports `--json` with structured, machine-parseable output. This means:
+- Keep collection platform-specific, but normalize analysis and output in shared Zig code.
+- Treat symbolization as a first-class component rather than a post-processing afterthought.
+- Model events and summaries with explicit schemas so terminal and JSON renderers consume the same internal data.
+- Avoid introducing a runtime-heavy dependency chain that pollutes measurements or complicates distribution.
 
-1. **Claude Code can call it**: `zigprofiler run --json ./program` → parse JSON → suggest optimizations
-2. **CI integration**: `zigprofiler bench --ci --threshold 5%` → fail if regression
-3. **Composable**: pipe output to other tools, feed into dashboards
-4. **Deterministic**: same input → same output (for reproducible bug reports)
+## Platform strategy
 
-### Agent workflow example
+Cross-platform does not mean pretending the platforms are identical.
 
-```
-Agent: "The user's RESP parser is slow. Let me profile it."
+Initial target:
 
-1. zigprofiler run --json ./faster-redis/zig-out/bin/test
-   → Finds findCRLF takes 40% of time
+- Linux
+- macOS
 
-2. zigprofiler bench --json --function findCRLF
-   → 58ns per call, SIMD path only taken for buffers >16 bytes
+Platform-specific collection is acceptable if the user-facing outputs remain consistent. A Linux backend might rely on `perf_event_open`, while macOS may need a different sampling path. That is an implementation detail. The CLI should preserve one mental model.
 
-3. Agent suggests: "Most RESP lines are <16 bytes. The SIMD path is skipped.
-   Add a fast scalar path for short strings before the SIMD loop."
+## What makes it Zig-aware
 
-4. User applies fix → zigprofiler bench --compare old new
-   → 58ns → 31ns, 1.87x improvement
-```
+“Zig-aware” needs to mean something concrete:
 
-## Implementation Plan
+- Symbolization that prefers Zig source names and file locations.
+- Memory tooling built around allocator usage rather than bolted-on heap snapshots alone.
+- Crash heuristics that understand common Zig failure patterns.
+- Rendering that respects Zig concepts such as slices, optionals, and error-returning control flow when presenting findings.
 
-### Phase 1: Core (week 1)
-- [ ] CLI skeleton with `run`, `bench`, `mem` subcommands
-- [ ] Basic sampling profiler (SIGPROF on macOS/Linux)
-- [ ] Zig symbolizer (parse DWARF from debug binary)
-- [ ] JSON output for all commands
-- [ ] `bench` with warmup detection + outlier trimming
+If the result could have been produced unchanged by a generic C profiler, then this tool is not differentiated enough.
 
-### Phase 2: Memory + Segfault (week 2)
-- [ ] Wrapping allocator that logs alloc/free with source location
-- [ ] Peak heap tracking + allocation flamegraph
-- [ ] SIGSEGV handler with register dump + stack trace
-- [ ] Root cause hinting (null deref, OOB, use-after-free)
+## v1 scope
 
-### Phase 3: FFI + Polish (week 3)
-- [ ] Python↔Zig boundary detection in stack traces
-- [ ] GIL state tracking via `_Py_IsFinalizing` / `PyGILState_Check`
-- [ ] Unified flamegraph (Python + Zig frames)
-- [ ] Terminal UI (live dashboard for `mem` mode)
-- [ ] `diff` command for profile comparison
+The current draft is ambitious. The right v1 is smaller.
 
-### Phase 4: Distribution
-- [ ] Single static binary (like nanobrew — small, no deps)
-- [ ] `brew install zigprofiler` / `cargo binstall zigprofiler`
-- [ ] GitHub Action for CI profiling
-- [ ] Claude Code skill integration
+Recommended v1:
 
-## Why Zig for a profiler?
+- `run`
+- `bench`
+- shared JSON output
+- symbolization pipeline
+- flamegraph generation
 
-- **No runtime overhead**: profiler itself shouldn't distort measurements
-- **Direct DWARF parsing**: Zig can read ELF/Mach-O debug info natively
-- **Signal handling**: Zig's `std.os` gives direct access to signal handlers
-- **Cross-platform**: same code for macOS (Instruments) and Linux (perf_events)
-- **Single binary**: 2MB profiler, no Python/Node/Java runtime needed
-- **Dog-fooding**: profile Zig code with a Zig profiler
+Recommended v1.1:
 
-## Comparison with existing tools
+- `mem`
+- `diff`
 
-| Tool | Language | Zig-aware | Agent-friendly | Memory | Segfault | FFI |
-|---|---|---|---|---|---|---|
-| `perf` | C | No | No | No | No | No |
-| Instruments | ObjC | No | No | Yes | No | No |
-| Valgrind | C | No | No | Yes | Yes | No |
-| Tracy | C++ | No | No | Yes | No | No |
-| **zigprofiler** | **Zig** | **Yes** | **Yes (JSON)** | **Yes** | **Yes** | **Yes** |
+Recommended v1.2:
 
-## Open Questions
+- `crash`
 
-- Should we use `dtrace` on macOS or implement our own sampler?
-- DWARF parsing: use Zig's `std.dwarf` or write custom?
-- How to handle optimized builds where debug info is stripped?
-- Should `zigprofiler ffi` support other languages (Ruby, Node)?
-- MCP server mode? (`zigprofiler serve --mcp` for direct Claude Code integration)
+Defer for now:
+
+- broad cross-language profiling
+- live TUI dashboards
+- MCP server mode
+- support for many non-Python host languages
+
+That ordering matters. A credible CPU profiler plus comparison workflow is already valuable. A half-built everything-suite is not.
+
+## Roadmap
+
+### Phase 1
+
+- Build CLI skeleton and shared output schema.
+- Implement sampling collection on one platform first.
+- Symbolize samples back to Zig source.
+- Emit terminal summaries and flamegraph-compatible output.
+- Add JSON mode and a fixture-driven test corpus.
+
+### Phase 2
+
+- Add benchmarking mode with baseline comparison.
+- Add profile diffing and regression reporting.
+- Harden symbolization for optimized and partially stripped binaries.
+- Validate outputs on real Zig workloads, not toy examples.
+
+### Phase 3
+
+- Add allocator instrumentation and memory summaries.
+- Add leak reporting and peak-heap analysis.
+- Add profile-memory cross-links where practical.
+
+### Phase 4
+
+- Add crash analysis path.
+- Improve heuristic diagnosis for common Zig failure modes.
+- Package for easy installation and CI usage.
+
+## Competitive position
+
+`zigprofiler` should complement existing tooling, not pretend it invented profiling.
+
+| Tool | Good at | Weak for Zig teams |
+| --- | --- | --- |
+| `perf` | Excellent low-level sampling on Linux | Raw and not Zig-oriented |
+| Instruments | Strong macOS profiling UI | Apple-specific and not Zig-aware |
+| Valgrind | Powerful memory diagnostics | Heavyweight, slower, not Zig-native |
+| Tracy | Great instrumentation workflow | Requires integration and is not source-semantic for Zig out of the box |
+| `zigprofiler` | Zig-oriented summaries, JSON workflows, agent usability | Must prove collection accuracy and platform maturity |
+
+## Why this should exist
+
+Zig is attracting exactly the kind of engineers who care about:
+
+- predictable performance
+- binary size
+- memory behavior
+- direct systems visibility
+
+Those engineers need tooling that meets them at the same level of precision. A profiler that speaks Zig well is a natural piece of the ecosystem.
+
+The strongest version of `zigprofiler` is not “a profiler written in Zig.” It is “the shortest path from low-level evidence to a correct Zig-specific optimization or debugging decision.”
+
+## Open questions
+
+These are the real questions worth resolving early:
+
+- Which collection backend gets us to a credible first release fastest on Linux?
+- What is the minimum viable symbolization pipeline for optimized Zig binaries?
+- How invasive can memory instrumentation be before it distorts the workloads users care about?
+- Should crash analysis be built in-process, out-of-process, or both?
+- What JSON schema boundaries should remain stable from day one?
+
+## Bottom line
+
+The idea is strong. The draft just needs a firmer shape.
+
+`zigprofiler` should be pitched as a focused developer tool for turning low-level runtime evidence into source-level Zig answers, with agent-grade structured output as a core feature rather than a gimmick.
+
+That framing is sharper, more defensible, and much easier to build against.

--- a/src/cmd/bench.zig
+++ b/src/cmd/bench.zig
@@ -1,0 +1,10 @@
+const output = @import("../output.zig");
+
+pub fn execute() output.Summary {
+    return .{
+        .kind = .bench,
+        .headline = "Benchmarking is not implemented yet.",
+        .detail =
+            "Planned v1 scope: repeated measurements, baseline comparison, regression thresholds, and JSON output suitable for CI and agent workflows.",
+    };
+}

--- a/src/cmd/crash.zig
+++ b/src/cmd/crash.zig
@@ -1,0 +1,94 @@
+const std = @import("std");
+const crash_backend = @import("../crash_backend.zig");
+const crash_report = @import("../crash_report.zig");
+
+pub const Options = struct {
+    target: []const u8,
+    target_args: []const []const u8,
+    backend: crash_backend.Backend,
+    max_output_bytes: usize,
+};
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !crash_report.CrashReport {
+    const options = try parseOptions(args);
+    return try crash_backend.collect(allocator, options.backend, .{
+        .binary = options.target,
+        .args = options.target_args,
+        .max_output_bytes = options.max_output_bytes,
+    });
+}
+
+fn parseOptions(args: []const []const u8) !Options {
+    if (args.len == 0) return error.MissingTarget;
+
+    var backend: crash_backend.Backend = .stub;
+    var max_output_bytes: usize = 1024 * 1024;
+    var target: ?[]const u8 = null;
+    var target_args: []const []const u8 = &.{};
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+
+        if (std.mem.eql(u8, arg, "--")) {
+            if (target == null) return error.MissingTarget;
+            target_args = args[i + 1 ..];
+            break;
+        }
+
+        if (std.mem.eql(u8, arg, "--backend")) {
+            i += 1;
+            if (i >= args.len) return error.MissingBackendValue;
+            backend = parseBackend(args[i]) orelse return error.UnknownBackend;
+            continue;
+        }
+
+        if (std.mem.eql(u8, arg, "--max-output-bytes")) {
+            i += 1;
+            if (i >= args.len) return error.MissingOutputLimitValue;
+            max_output_bytes = try std.fmt.parseInt(usize, args[i], 10);
+            continue;
+        }
+
+        if (std.mem.startsWith(u8, arg, "-")) return error.UnknownCrashFlag;
+        if (target != null) return error.UnexpectedArgument;
+        target = arg;
+    }
+
+    return .{
+        .target = target orelse return error.MissingTarget,
+        .target_args = target_args,
+        .backend = backend,
+        .max_output_bytes = max_output_bytes,
+    };
+}
+
+fn parseBackend(raw: []const u8) ?crash_backend.Backend {
+    if (std.mem.eql(u8, raw, "stub")) return .stub;
+    if (std.mem.eql(u8, raw, "supervisor")) return .supervisor;
+    return null;
+}
+
+test "parseOptions requires target" {
+    try std.testing.expectError(error.MissingTarget, parseOptions(&.{}));
+}
+
+test "parseOptions accepts backend and passthrough args" {
+    const options = try parseOptions(&.{ "--backend", "stub", "./zig-out/bin/app", "--", "--port", "6379" });
+    try std.testing.expectEqual(crash_backend.Backend.stub, options.backend);
+    try std.testing.expectEqual(@as(usize, 1024 * 1024), options.max_output_bytes);
+    try std.testing.expectEqualStrings("./zig-out/bin/app", options.target);
+    try std.testing.expectEqual(@as(usize, 2), options.target_args.len);
+    try std.testing.expectEqualStrings("--port", options.target_args[0]);
+    try std.testing.expectEqualStrings("6379", options.target_args[1]);
+}
+
+test "parseOptions accepts supervisor backend" {
+    const options = try parseOptions(&.{ "--backend", "supervisor", "./zig-out/bin/app" });
+    try std.testing.expectEqual(crash_backend.Backend.supervisor, options.backend);
+}
+
+test "parseOptions accepts output limit override" {
+    const options = try parseOptions(&.{ "--max-output-bytes", "2048", "./zig-out/bin/app" });
+    try std.testing.expectEqual(@as(usize, 2048), options.max_output_bytes);
+}

--- a/src/cmd/diff.zig
+++ b/src/cmd/diff.zig
@@ -1,0 +1,10 @@
+const output = @import("../output.zig");
+
+pub fn execute() output.Summary {
+    return .{
+        .kind = .diff,
+        .headline = "Artifact diffing is not implemented yet.",
+        .detail =
+            "This command will compare benchmark and profile outputs to surface regressions, new hotspots, and changed allocation pressure.",
+    };
+}

--- a/src/cmd/mem.zig
+++ b/src/cmd/mem.zig
@@ -1,0 +1,10 @@
+const output = @import("../output.zig");
+
+pub fn execute() output.Summary {
+    return .{
+        .kind = .mem,
+        .headline = "Memory profiling is not implemented yet.",
+        .detail =
+            "Planned follow-up scope: allocator instrumentation, live and peak heap summaries, leak reporting, and allocation-site aggregation.",
+    };
+}

--- a/src/cmd/run.zig
+++ b/src/cmd/run.zig
@@ -1,0 +1,88 @@
+const std = @import("std");
+const collector = @import("../collector.zig");
+const profile = @import("../profile.zig");
+
+pub const Options = struct {
+    target: []const u8,
+    target_args: []const []const u8,
+    duration_ms: u32,
+    backend: collector.Backend,
+};
+
+pub fn execute(allocator: std.mem.Allocator, args: []const []const u8) !profile.CpuProfile {
+    const options = try parseOptions(args);
+    return try collector.collect(allocator, options.backend, .{
+        .binary = options.target,
+        .args = options.target_args,
+        .duration_ms = options.duration_ms,
+    });
+}
+
+fn parseOptions(args: []const []const u8) !Options {
+    if (args.len == 0) return error.MissingTarget;
+
+    var duration_ms: u32 = 2000;
+    var backend: collector.Backend = .stub;
+    var target: ?[]const u8 = null;
+    var target_args: []const []const u8 = &.{};
+
+    var i: usize = 0;
+    while (i < args.len) : (i += 1) {
+        const arg = args[i];
+
+        if (std.mem.eql(u8, arg, "--")) {
+            if (target == null) return error.MissingTarget;
+            target_args = args[i + 1 ..];
+            break;
+        }
+
+        if (std.mem.eql(u8, arg, "--duration-ms")) {
+            i += 1;
+            if (i >= args.len) return error.MissingDurationValue;
+            duration_ms = try std.fmt.parseInt(u32, args[i], 10);
+            continue;
+        }
+
+        if (std.mem.eql(u8, arg, "--backend")) {
+            i += 1;
+            if (i >= args.len) return error.MissingBackendValue;
+            backend = parseBackend(args[i]) orelse return error.UnknownBackend;
+            continue;
+        }
+
+        if (std.mem.startsWith(u8, arg, "-")) return error.UnknownRunFlag;
+        if (target != null) return error.UnexpectedArgument;
+        target = arg;
+    }
+
+    return .{
+        .target = target orelse return error.MissingTarget,
+        .target_args = target_args,
+        .duration_ms = duration_ms,
+        .backend = backend,
+    };
+}
+
+fn parseBackend(raw: []const u8) ?collector.Backend {
+    if (std.mem.eql(u8, raw, "stub")) return .stub;
+    return null;
+}
+
+test "parseOptions requires target" {
+    try std.testing.expectError(error.MissingTarget, parseOptions(&.{}));
+}
+
+test "parseOptions handles duration and passthrough args" {
+    const options = try parseOptions(&.{ "--duration-ms", "1500", "./zig-out/bin/app", "--", "--port", "6379" });
+    try std.testing.expectEqual(@as(u32, 1500), options.duration_ms);
+    try std.testing.expectEqualStrings("./zig-out/bin/app", options.target);
+    try std.testing.expectEqual(@as(usize, 2), options.target_args.len);
+    try std.testing.expectEqualStrings("--port", options.target_args[0]);
+    try std.testing.expectEqualStrings("6379", options.target_args[1]);
+    try std.testing.expectEqual(collector.Backend.stub, options.backend);
+}
+
+test "parseOptions accepts backend override" {
+    const options = try parseOptions(&.{ "--backend", "stub", "./zig-out/bin/app" });
+    try std.testing.expectEqual(collector.Backend.stub, options.backend);
+}

--- a/src/collector.zig
+++ b/src/collector.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const profile = @import("profile.zig");
+
+pub const Options = struct {
+    binary: []const u8,
+    args: []const []const u8,
+    duration_ms: u32,
+};
+
+pub const Backend = enum {
+    stub,
+
+    pub fn asString(self: Backend) []const u8 {
+        return switch (self) {
+            .stub => "stub",
+        };
+    }
+};
+
+pub fn collect(allocator: std.mem.Allocator, backend: Backend, options: Options) !profile.CpuProfile {
+    return switch (backend) {
+        .stub => @import("collector/stub.zig").collect(allocator, options),
+    };
+}

--- a/src/collector/stub.zig
+++ b/src/collector/stub.zig
@@ -1,0 +1,61 @@
+const std = @import("std");
+const collector = @import("../collector.zig");
+const profile = @import("../profile.zig");
+
+pub fn collect(allocator: std.mem.Allocator, options: collector.Options) !profile.CpuProfile {
+    const basename = std.fs.path.basename(options.binary);
+    const primary_name = try std.fmt.allocPrint(allocator, "{s}.mainLoop", .{basename});
+    const secondary_name = try std.fmt.allocPrint(allocator, "{s}.parseFrame", .{basename});
+    const tertiary_name = try std.fmt.allocPrint(allocator, "{s}.flushWrites", .{basename});
+
+    const functions = try allocator.alloc(profile.FunctionStat, 3);
+    functions[0] = .{
+        .name = primary_name,
+        .file = "src/main.zig",
+        .line = 84,
+        .self_pct = 34.8,
+        .total_pct = 61.2,
+        .samples = options.duration_ms / 2,
+    };
+    functions[1] = .{
+        .name = secondary_name,
+        .file = "src/profile.zig",
+        .line = 47,
+        .self_pct = 21.5,
+        .total_pct = 29.4,
+        .samples = options.duration_ms / 3,
+    };
+    functions[2] = .{
+        .name = tertiary_name,
+        .file = "src/io.zig",
+        .line = 133,
+        .self_pct = 13.1,
+        .total_pct = 18.7,
+        .samples = options.duration_ms / 5,
+    };
+
+    const hotspots = try allocator.alloc(profile.Hotspot, 2);
+    hotspots[0] = .{
+        .file = "src/main.zig",
+        .line = 91,
+        .label = "dispatch loop",
+        .self_pct = 16.8,
+    };
+    hotspots[1] = .{
+        .file = "src/profile.zig",
+        .line = 53,
+        .label = "frame decode branch",
+        .self_pct = 9.7,
+    };
+
+    return .{
+        .binary = options.binary,
+        .args = options.args,
+        .duration_ms = options.duration_ms,
+        .samples = options.duration_ms,
+        .collector = collector.Backend.stub.asString(),
+        .notes = "Synthetic profile for CLI scaffolding. Replace the stub collector with a platform sampler next.",
+        .functions = functions,
+        .hotspots = hotspots,
+    };
+}

--- a/src/crash_backend.zig
+++ b/src/crash_backend.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const crash_report = @import("crash_report.zig");
+
+pub const Options = struct {
+    binary: []const u8,
+    args: []const []const u8,
+    max_output_bytes: usize,
+};
+
+pub const Backend = enum {
+    stub,
+    supervisor,
+
+    pub fn asString(self: Backend) []const u8 {
+        return switch (self) {
+            .stub => "stub",
+            .supervisor => "supervisor",
+        };
+    }
+};
+
+pub fn collect(allocator: std.mem.Allocator, backend: Backend, options: Options) !crash_report.CrashReport {
+    return switch (backend) {
+        .stub => @import("crash_backend/stub.zig").collect(allocator, options),
+        .supervisor => @import("crash_backend/supervisor.zig").collect(allocator, options),
+    };
+}

--- a/src/crash_backend/stub.zig
+++ b/src/crash_backend/stub.zig
@@ -1,0 +1,37 @@
+const std = @import("std");
+const crash_backend = @import("../crash_backend.zig");
+const crash_report = @import("../crash_report.zig");
+
+pub fn collect(allocator: std.mem.Allocator, options: crash_backend.Options) !crash_report.CrashReport {
+    _ = options.max_output_bytes;
+    const basename = std.fs.path.basename(options.binary);
+    const summary = try std.fmt.allocPrint(allocator, "{s} terminated with a synthetic SIGSEGV report.", .{basename});
+    const probable_cause = "likely null optional dereference or invalid pointer use near a Zig call boundary";
+
+    const stack = try allocator.alloc(crash_report.StackFrame, 3);
+    stack[0] = .{ .file = "src/client.zig", .line = 92, .symbol = "RedisClient.send" };
+    stack[1] = .{ .file = "src/client.zig", .line = 57, .symbol = "RedisClient.command" };
+    stack[2] = .{ .file = "src/main.zig", .line = 78, .symbol = "py_command" };
+
+    const registers = try allocator.alloc(crash_report.RegisterValue, 2);
+    registers[0] = .{ .name = "x0", .value = "0x0000000000000000", .meaning = "possible null receiver pointer" };
+    registers[1] = .{ .name = "x1", .value = "0x000000016fdfc000", .meaning = "possible slice/data pointer" };
+
+    return .{
+        .binary = options.binary,
+        .args = options.args,
+        .backend = crash_backend.Backend.stub.asString(),
+        .termination = "signal",
+        .exit_code = null,
+        .signal_number = 11,
+        .signal_name = "SIGSEGV",
+        .fault_address = "0x0000000000000008",
+        .summary = summary,
+        .probable_cause = probable_cause,
+        .notes = "Synthetic crash report for scaffolding. Replace the stub backend with a supervisor that captures real signal exits, crash artifacts, and symbolized stacks.",
+        .stdout = "",
+        .stderr = "",
+        .stack = stack,
+        .registers = registers,
+    };
+}

--- a/src/crash_backend/supervisor.zig
+++ b/src/crash_backend/supervisor.zig
@@ -1,0 +1,189 @@
+const std = @import("std");
+const crash_backend = @import("../crash_backend.zig");
+const crash_report = @import("../crash_report.zig");
+
+pub fn collect(allocator: std.mem.Allocator, options: crash_backend.Options) !crash_report.CrashReport {
+    const argv = try buildArgv(allocator, options);
+    const result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = argv,
+        .max_output_bytes = options.max_output_bytes,
+    }) catch |err| return buildExecutionFailureReport(allocator, options, err);
+
+    const classification = classifyTermination(result.term);
+
+    return .{
+        .binary = options.binary,
+        .args = options.args,
+        .backend = crash_backend.Backend.supervisor.asString(),
+        .termination = classification.termination,
+        .exit_code = classification.exit_code,
+        .signal_number = classification.signal_number,
+        .signal_name = classification.signal_name,
+        .fault_address = "unknown",
+        .summary = classification.summary,
+        .probable_cause = classification.probable_cause,
+        .notes = "Supervisor backend captured child termination and stdio. Stack symbolization, core dump ingestion, and register extraction are the next layer.",
+        .stdout = result.stdout,
+        .stderr = result.stderr,
+        .stack = try allocator.alloc(crash_report.StackFrame, 0),
+        .registers = try allocator.alloc(crash_report.RegisterValue, 0),
+    };
+}
+
+fn buildArgv(allocator: std.mem.Allocator, options: crash_backend.Options) ![]const []const u8 {
+    const argv = try allocator.alloc([]const u8, options.args.len + 1);
+    argv[0] = options.binary;
+    for (options.args, 0..) |arg, index| argv[index + 1] = arg;
+    return argv;
+}
+
+    const Classification = struct {
+    termination: []const u8,
+    exit_code: ?u32,
+    signal_number: ?u32,
+    signal_name: []const u8,
+    summary: []const u8,
+    probable_cause: []const u8,
+};
+
+fn classifyTermination(term: std.process.Child.Term) Classification {
+    return switch (term) {
+        .Exited => |code| if (code == 0)
+            .{
+                .termination = "exited",
+                .exit_code = code,
+                .signal_number = null,
+                .signal_name = "none",
+                .summary = "process exited cleanly; no crash captured",
+                .probable_cause = "none",
+            }
+        else
+            .{
+                .termination = "exited",
+                .exit_code = code,
+                .signal_number = null,
+                .signal_name = "none",
+                .summary = "process exited with a non-zero code",
+                .probable_cause = "process failure without signal; inspect stderr and application logs",
+            },
+        .Signal => |signal| .{
+            .termination = "signal",
+            .exit_code = null,
+            .signal_number = signal,
+            .signal_name = signalName(signal),
+            .summary = signalSummary(signal),
+            .probable_cause = probableCause(signal),
+        },
+        .Stopped => |signal| .{
+            .termination = "stopped",
+            .exit_code = null,
+            .signal_number = signal,
+            .signal_name = signalName(signal),
+            .summary = "process was stopped by a signal before normal exit",
+            .probable_cause = "external debugger, job control, or an intermediate signal interrupted execution",
+        },
+        .Unknown => |_| .{
+            .termination = "unknown",
+            .exit_code = null,
+            .signal_number = null,
+            .signal_name = "unknown",
+            .summary = "process termination could not be classified",
+            .probable_cause = "platform-specific process state; inspect stderr and rerun under a debugger",
+        },
+    };
+}
+
+fn buildExecutionFailureReport(
+    allocator: std.mem.Allocator,
+    options: crash_backend.Options,
+    err: anyerror,
+) !crash_report.CrashReport {
+    const err_name = @errorName(err);
+
+    const summary = switch (err) {
+        error.StdoutStreamTooLong, error.StderrStreamTooLong => "supervisor failed while collecting child output",
+        else => "supervisor failed before a crash report could be collected from the target process",
+    };
+
+    const probable_cause = switch (err) {
+        error.StdoutStreamTooLong, error.StderrStreamTooLong => "child process produced more output than the current capture limit allows",
+        error.FileNotFound => "target binary could not be found",
+        error.AccessDenied => "target binary could not be executed due to permissions",
+        else => "process launch or output collection failed before termination could be classified",
+    };
+
+    const notes = try std.fmt.allocPrint(
+        allocator,
+        "Supervisor backend error: {s}. Increase output limits or inspect the target path and runtime environment.",
+        .{err_name},
+    );
+    const stderr = try std.fmt.allocPrint(allocator, "supervisor error: {s}\n", .{err_name});
+
+    return .{
+        .binary = options.binary,
+        .args = options.args,
+        .backend = crash_backend.Backend.supervisor.asString(),
+        .termination = "collection_error",
+        .exit_code = null,
+        .signal_number = null,
+        .signal_name = "unknown",
+        .fault_address = "unknown",
+        .summary = summary,
+        .probable_cause = probable_cause,
+        .notes = notes,
+        .stdout = "",
+        .stderr = stderr,
+        .stack = try allocator.alloc(crash_report.StackFrame, 0),
+        .registers = try allocator.alloc(crash_report.RegisterValue, 0),
+    };
+}
+
+fn signalName(signal: u32) []const u8 {
+    return switch (signal) {
+        4 => "SIGILL",
+        6 => "SIGABRT",
+        8 => "SIGFPE",
+        10 => "SIGBUS",
+        11 => "SIGSEGV",
+        5 => "SIGTRAP",
+        else => "signal",
+    };
+}
+
+fn signalSummary(signal: u32) []const u8 {
+    return switch (signal) {
+        11 => "process terminated with SIGSEGV",
+        10 => "process terminated with SIGBUS",
+        6 => "process terminated with SIGABRT",
+        8 => "process terminated with SIGFPE",
+        4 => "process terminated with SIGILL",
+        else => "process terminated with a signal",
+    };
+}
+
+fn probableCause(signal: u32) []const u8 {
+    return switch (signal) {
+        11 => "likely invalid pointer dereference, null optional access, out-of-bounds pointer arithmetic, or FFI memory misuse",
+        10 => "likely invalid memory alignment, bad mapping access, or low-level buffer misuse",
+        6 => "likely explicit abort, failed assertion, panic-to-abort path, or allocator/runtime consistency failure",
+        8 => "likely division-by-zero or invalid arithmetic state",
+        4 => "likely bad instruction stream, corrupted control flow, or incompatible generated code",
+        else => "signal-triggered failure; inspect stderr and rerun with symbolization enabled",
+    };
+}
+
+test "classifyTermination handles clean exit" {
+    const classification = classifyTermination(.{ .Exited = 0 });
+    try std.testing.expectEqualStrings("exited", classification.termination);
+    try std.testing.expectEqual(@as(?u32, 0), classification.exit_code);
+    try std.testing.expectEqual(@as(?u32, null), classification.signal_number);
+}
+
+test "classifyTermination handles signal" {
+    const classification = classifyTermination(.{ .Signal = 11 });
+    try std.testing.expectEqualStrings("signal", classification.termination);
+    try std.testing.expectEqual(@as(?u32, null), classification.exit_code);
+    try std.testing.expectEqual(@as(?u32, 11), classification.signal_number);
+    try std.testing.expectEqualStrings("SIGSEGV", classification.signal_name);
+}

--- a/src/crash_report.zig
+++ b/src/crash_report.zig
@@ -1,0 +1,153 @@
+const std = @import("std");
+const output = @import("output.zig");
+
+pub const StackFrame = struct {
+    file: []const u8,
+    line: u32,
+    symbol: []const u8,
+};
+
+pub const RegisterValue = struct {
+    name: []const u8,
+    value: []const u8,
+    meaning: []const u8,
+};
+
+pub const CrashReport = struct {
+    binary: []const u8,
+    args: []const []const u8,
+    backend: []const u8,
+    termination: []const u8,
+    exit_code: ?u32,
+    signal_number: ?u32,
+    signal_name: []const u8,
+    fault_address: []const u8,
+    summary: []const u8,
+    probable_cause: []const u8,
+    notes: []const u8,
+    stdout: []const u8,
+    stderr: []const u8,
+    stack: []const StackFrame,
+    registers: []const RegisterValue,
+
+    pub fn render(self: CrashReport, writer: anytype, format: output.Format) !void {
+        switch (format) {
+            .text => try self.renderText(writer),
+            .json => try self.renderJson(writer),
+        }
+    }
+
+    fn renderText(self: CrashReport, writer: anytype) !void {
+        try writer.print("Crash report for {s}\n", .{self.binary});
+        try writer.print("backend: {s}\n", .{self.backend});
+        try writer.print("termination: {s}\n", .{self.termination});
+        if (self.exit_code) |exit_code| {
+            try writer.print("exit code: {d}\n", .{exit_code});
+        }
+        if (self.signal_number) |signal_number| {
+            try writer.print("signal number: {d}\n", .{signal_number});
+        }
+        try writer.print("signal: {s}\n", .{self.signal_name});
+        try writer.print("fault address: {s}\n", .{self.fault_address});
+        if (self.args.len != 0) {
+            try writer.writeAll("target args: ");
+            for (self.args, 0..) |arg, index| {
+                if (index != 0) try writer.writeAll(" ");
+                try writer.writeAll(arg);
+            }
+            try writer.writeByte('\n');
+        }
+        try writer.print("summary: {s}\n", .{self.summary});
+        try writer.print("probable cause: {s}\n", .{self.probable_cause});
+        try writer.print("notes: {s}\n", .{self.notes});
+
+        if (self.stdout.len != 0) {
+            try writer.writeAll("\nCaptured stdout\n");
+            try writer.writeAll(self.stdout);
+            if (self.stdout[self.stdout.len - 1] != '\n') try writer.writeByte('\n');
+        }
+
+        if (self.stderr.len != 0) {
+            try writer.writeAll("\nCaptured stderr\n");
+            try writer.writeAll(self.stderr);
+            if (self.stderr[self.stderr.len - 1] != '\n') try writer.writeByte('\n');
+        }
+
+        if (self.stack.len != 0) {
+            try writer.writeAll("\nStack\n");
+            for (self.stack) |frame| {
+                try writer.print("  {s}:{d}  {s}\n", .{ frame.file, frame.line, frame.symbol });
+            }
+        }
+
+        if (self.registers.len != 0) {
+            try writer.writeAll("\nRegisters\n");
+            for (self.registers) |register| {
+                try writer.print("  {s} = {s}  {s}\n", .{ register.name, register.value, register.meaning });
+            }
+        }
+    }
+
+    fn renderJson(self: CrashReport, writer: anytype) !void {
+        try writer.writeAll("{\n");
+        try writer.writeAll("  \"kind\": \"crash_report\",\n");
+        try writer.writeAll("  \"binary\": ");
+        try output.writeJsonString(writer, self.binary);
+        try writer.writeAll(",\n  \"args\": ");
+        try output.writeJsonStringArray(writer, self.args);
+        try writer.writeAll(",\n  \"backend\": ");
+        try output.writeJsonString(writer, self.backend);
+        try writer.writeAll(",\n  \"termination\": ");
+        try output.writeJsonString(writer, self.termination);
+        try writer.writeAll(",\n  \"exit_code\": ");
+        try writeOptionalU32(writer, self.exit_code);
+        try writer.writeAll(",\n  \"signal_number\": ");
+        try writeOptionalU32(writer, self.signal_number);
+        try writer.writeAll(",\n  \"signal\": ");
+        try output.writeJsonString(writer, self.signal_name);
+        try writer.writeAll(",\n  \"fault_address\": ");
+        try output.writeJsonString(writer, self.fault_address);
+        try writer.writeAll(",\n  \"summary\": ");
+        try output.writeJsonString(writer, self.summary);
+        try writer.writeAll(",\n  \"probable_cause\": ");
+        try output.writeJsonString(writer, self.probable_cause);
+        try writer.writeAll(",\n  \"notes\": ");
+        try output.writeJsonString(writer, self.notes);
+        try writer.writeAll(",\n  \"stdout\": ");
+        try output.writeJsonString(writer, self.stdout);
+        try writer.writeAll(",\n  \"stderr\": ");
+        try output.writeJsonString(writer, self.stderr);
+        try writer.writeAll(",\n  \"stack\": [\n");
+        for (self.stack, 0..) |frame, index| {
+            if (index != 0) try writer.writeAll(",\n");
+            try writer.writeAll("    {\n");
+            try writer.writeAll("      \"file\": ");
+            try output.writeJsonString(writer, frame.file);
+            try writer.print(",\n      \"line\": {d},\n", .{frame.line});
+            try writer.writeAll("      \"symbol\": ");
+            try output.writeJsonString(writer, frame.symbol);
+            try writer.writeAll("\n    }");
+        }
+        try writer.writeAll("\n  ],\n  \"registers\": [\n");
+        for (self.registers, 0..) |register, index| {
+            if (index != 0) try writer.writeAll(",\n");
+            try writer.writeAll("    {\n");
+            try writer.writeAll("      \"name\": ");
+            try output.writeJsonString(writer, register.name);
+            try writer.writeAll(",\n      \"value\": ");
+            try output.writeJsonString(writer, register.value);
+            try writer.writeAll(",\n      \"meaning\": ");
+            try output.writeJsonString(writer, register.meaning);
+            try writer.writeAll("\n    }");
+        }
+        try writer.writeAll("\n  ]\n}\n");
+    }
+};
+
+fn writeOptionalU32(writer: anytype, value: ?u32) !void {
+    if (value) |number| {
+        try writer.print("{d}", .{number});
+    } else {
+        try writer.writeAll("null");
+    }
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,0 +1,168 @@
+const std = @import("std");
+
+const bench_cmd = @import("cmd/bench.zig");
+const crash_cmd = @import("cmd/crash.zig");
+const diff_cmd = @import("cmd/diff.zig");
+const mem_cmd = @import("cmd/mem.zig");
+const output = @import("output.zig");
+const run_cmd = @import("cmd/run.zig");
+
+const usage_text =
+    \\zigprofiler
+    \\
+    \\Usage:
+    \\  zigprofiler <command> [--json] [command options]
+    \\
+    \\Commands:
+    \\  run     CPU profiling
+    \\  mem     memory profiling
+    \\  crash   crash and fault analysis
+    \\  bench   benchmark execution
+    \\  diff    compare profile or benchmark artifacts
+    \\  help    show this message
+    \\
+    \\Run options:
+    \\  zigprofiler run [--json] [--duration-ms <ms>] [--backend <name>] <binary> [-- <target args...>]
+    \\
+    \\Crash options:
+    \\  zigprofiler crash [--json] [--backend <name>] [--max-output-bytes <n>] <binary> [-- <target args...>]
+    \\  backends: stub, supervisor
+    \\  supervisor currently captures termination and stdio only
+    \\
+;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const argv = try std.process.argsAlloc(allocator);
+    defer std.process.argsFree(allocator, argv);
+
+    var stdout_file = std.fs.File.stdout();
+    var stdout_buffer: [4096]u8 = undefined;
+    var stdout_writer = stdout_file.writer(&stdout_buffer);
+    const stdout = &stdout_writer.interface;
+    defer stdout.flush() catch {};
+
+    const parsed = try parseArgs(allocator, argv);
+    defer allocator.free(parsed.command_args);
+
+    switch (parsed.command) {
+        .help => try stdout.writeAll(usage_text),
+        .run => {
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+            try (try run_cmd.execute(arena.allocator(), parsed.command_args)).render(stdout, parsed.format);
+        },
+        .mem => try mem_cmd.execute().render(stdout, parsed.format),
+        .crash => {
+            var arena = std.heap.ArenaAllocator.init(allocator);
+            defer arena.deinit();
+            try (try crash_cmd.execute(arena.allocator(), parsed.command_args)).render(stdout, parsed.format);
+        },
+        .bench => try bench_cmd.execute().render(stdout, parsed.format),
+        .diff => try diff_cmd.execute().render(stdout, parsed.format),
+    }
+}
+
+const ParsedArgs = struct {
+    command: Command,
+    format: output.Format,
+    command_args: []const []const u8,
+};
+
+const Command = enum {
+    help,
+    run,
+    mem,
+    crash,
+    bench,
+    diff,
+};
+
+fn parseArgs(allocator: std.mem.Allocator, argv: []const []const u8) !ParsedArgs {
+    if (argv.len <= 1) {
+        return .{ .command = .help, .format = .text, .command_args = try allocator.alloc([]const u8, 0) };
+    }
+
+    var format: output.Format = .text;
+    var command: ?Command = null;
+    var command_args_builder = std.ArrayList([]const u8).empty;
+    defer command_args_builder.deinit(allocator);
+
+    for (argv[1..]) |arg| {
+        if (std.mem.eql(u8, arg, "--json")) {
+            format = .json;
+            continue;
+        }
+
+        if (command == null) {
+            if (std.mem.startsWith(u8, arg, "-")) {
+                if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+                    command = .help;
+                    continue;
+                }
+                return error.UnknownFlag;
+            }
+
+            command = parseCommand(arg) orelse return error.UnknownCommand;
+            continue;
+        }
+
+        try command_args_builder.append(allocator, arg);
+    }
+
+    if (command == null) {
+        command = .help;
+    }
+
+    return .{
+        .command = command orelse .help,
+        .format = format,
+        .command_args = try command_args_builder.toOwnedSlice(allocator),
+    };
+}
+
+fn parseCommand(arg: []const u8) ?Command {
+    if (std.mem.eql(u8, arg, "run")) return .run;
+    if (std.mem.eql(u8, arg, "mem")) return .mem;
+    if (std.mem.eql(u8, arg, "crash")) return .crash;
+    if (std.mem.eql(u8, arg, "bench")) return .bench;
+    if (std.mem.eql(u8, arg, "diff")) return .diff;
+    if (std.mem.eql(u8, arg, "help")) return .help;
+    return null;
+}
+
+test "parseArgs defaults to help" {
+    const parsed = try parseArgs(std.testing.allocator, &.{"zigprofiler"});
+    defer std.testing.allocator.free(parsed.command_args);
+    try std.testing.expectEqual(Command.help, parsed.command);
+    try std.testing.expectEqual(output.Format.text, parsed.format);
+}
+
+test "parseArgs handles command and json format" {
+    const parsed = try parseArgs(std.testing.allocator, &.{ "zigprofiler", "crash", "--json" });
+    defer std.testing.allocator.free(parsed.command_args);
+    try std.testing.expectEqual(Command.crash, parsed.command);
+    try std.testing.expectEqual(output.Format.json, parsed.format);
+}
+
+test "parseArgs rejects unknown flag" {
+    try std.testing.expectError(error.UnknownFlag, parseArgs(std.testing.allocator, &.{ "zigprofiler", "--wat" }));
+}
+
+test "parseArgs rejects unknown command" {
+    try std.testing.expectError(error.UnknownCommand, parseArgs(std.testing.allocator, &.{ "zigprofiler", "wat" }));
+}
+
+test "parseArgs keeps command args after subcommand" {
+    const parsed = try parseArgs(std.testing.allocator, &.{ "zigprofiler", "run", "--json", "--duration-ms", "500", "./app" });
+    defer std.testing.allocator.free(parsed.command_args);
+    try std.testing.expectEqual(Command.run, parsed.command);
+    try std.testing.expectEqual(output.Format.json, parsed.format);
+    try std.testing.expectEqual(@as(usize, 3), parsed.command_args.len);
+    try std.testing.expectEqualStrings("--duration-ms", parsed.command_args[0]);
+    try std.testing.expectEqualStrings("500", parsed.command_args[1]);
+    try std.testing.expectEqualStrings("./app", parsed.command_args[2]);
+}

--- a/src/output.zig
+++ b/src/output.zig
@@ -1,0 +1,72 @@
+const std = @import("std");
+
+pub const Format = enum {
+    text,
+    json,
+};
+
+pub const CommandKind = enum {
+    run,
+    mem,
+    crash,
+    bench,
+    diff,
+
+    pub fn asString(kind: CommandKind) []const u8 {
+        return switch (kind) {
+            .run => "run",
+            .mem => "mem",
+            .crash => "crash",
+            .bench => "bench",
+            .diff => "diff",
+        };
+    }
+};
+
+pub const Summary = struct {
+    kind: CommandKind,
+    headline: []const u8,
+    detail: []const u8,
+
+    pub fn render(self: Summary, writer: anytype, format: Format) !void {
+        switch (format) {
+            .text => try writer.print("{s}\n\n{s}\n", .{ self.headline, self.detail }),
+            .json => {
+                try writer.writeAll("{\n");
+                try writer.print("  \"kind\": \"{s}\",\n", .{self.kind.asString()});
+                try writer.print("  \"headline\": ", .{});
+                try writeJsonString(writer, self.headline);
+                try writer.writeAll(",\n  \"detail\": ");
+                try writeJsonString(writer, self.detail);
+                try writer.writeAll("\n}\n");
+            },
+        }
+    }
+};
+
+pub fn writeJsonString(writer: anytype, value: []const u8) !void {
+    try writer.writeByte('"');
+    for (value) |byte| {
+        switch (byte) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            0x08 => try writer.writeAll("\\b"),
+            0x0C => try writer.writeAll("\\f"),
+            0x00...0x07, 0x0B, 0x0E...0x1F => try writer.print("\\u{X:0>4}", .{byte}),
+            else => try writer.writeByte(byte),
+        }
+    }
+    try writer.writeByte('"');
+}
+
+pub fn writeJsonStringArray(writer: anytype, values: []const []const u8) !void {
+    try writer.writeByte('[');
+    for (values, 0..) |value, index| {
+        if (index != 0) try writer.writeAll(", ");
+        try writeJsonString(writer, value);
+    }
+    try writer.writeByte(']');
+}

--- a/src/profile.zig
+++ b/src/profile.zig
@@ -1,0 +1,110 @@
+const std = @import("std");
+const output = @import("output.zig");
+
+pub const FunctionStat = struct {
+    name: []const u8,
+    file: []const u8,
+    line: u32,
+    self_pct: f32,
+    total_pct: f32,
+    samples: u32,
+};
+
+pub const Hotspot = struct {
+    file: []const u8,
+    line: u32,
+    label: []const u8,
+    self_pct: f32,
+};
+
+pub const CpuProfile = struct {
+    binary: []const u8,
+    args: []const []const u8,
+    duration_ms: u32,
+    samples: u32,
+    collector: []const u8,
+    notes: []const u8,
+    functions: []const FunctionStat,
+    hotspots: []const Hotspot,
+
+    pub fn render(self: CpuProfile, writer: anytype, format: output.Format) !void {
+        switch (format) {
+            .text => try self.renderText(writer),
+            .json => try self.renderJson(writer),
+        }
+    }
+
+    fn renderText(self: CpuProfile, writer: anytype) !void {
+        try writer.print("CPU profile for {s}\n", .{self.binary});
+        try writer.print("collector: {s}\n", .{self.collector});
+        try writer.print("duration: {d} ms\n", .{self.duration_ms});
+        try writer.print("samples: {d}\n", .{self.samples});
+        if (self.args.len != 0) {
+            try writer.writeAll("target args: ");
+            for (self.args, 0..) |arg, index| {
+                if (index != 0) try writer.writeAll(" ");
+                try writer.writeAll(arg);
+            }
+            try writer.writeByte('\n');
+        }
+        try writer.print("notes: {s}\n", .{self.notes});
+
+        try writer.writeAll("\nTop functions by self time\n");
+        for (self.functions) |function| {
+            try writer.print(
+                "  {d: >5.1}% self  {d: >5.1}% total  {d: >5} samples  {s}  ({s}:{d})\n",
+                .{ function.self_pct, function.total_pct, function.samples, function.name, function.file, function.line },
+            );
+        }
+
+        try writer.writeAll("\nHot lines\n");
+        for (self.hotspots) |hotspot| {
+            try writer.print(
+                "  {d: >5.1}%  {s}:{d}  {s}\n",
+                .{ hotspot.self_pct, hotspot.file, hotspot.line, hotspot.label },
+            );
+        }
+    }
+
+    fn renderJson(self: CpuProfile, writer: anytype) !void {
+        try writer.writeAll("{\n");
+        try writer.writeAll("  \"kind\": \"cpu_profile\",\n");
+        try writer.writeAll("  \"binary\": ");
+        try output.writeJsonString(writer, self.binary);
+        try writer.writeAll(",\n  \"args\": ");
+        try output.writeJsonStringArray(writer, self.args);
+        try writer.print(",\n  \"duration_ms\": {d},\n", .{self.duration_ms});
+        try writer.print("  \"samples\": {d},\n", .{self.samples});
+        try writer.writeAll("  \"collector\": ");
+        try output.writeJsonString(writer, self.collector);
+        try writer.writeAll(",\n  \"notes\": ");
+        try output.writeJsonString(writer, self.notes);
+        try writer.writeAll(",\n  \"functions\": [\n");
+        for (self.functions, 0..) |function, index| {
+            if (index != 0) try writer.writeAll(",\n");
+            try writer.writeAll("    {\n");
+            try writer.writeAll("      \"name\": ");
+            try output.writeJsonString(writer, function.name);
+            try writer.writeAll(",\n      \"file\": ");
+            try output.writeJsonString(writer, function.file);
+            try writer.print(",\n      \"line\": {d},\n", .{function.line});
+            try writer.print("      \"self_pct\": {d:.1},\n", .{function.self_pct});
+            try writer.print("      \"total_pct\": {d:.1},\n", .{function.total_pct});
+            try writer.print("      \"samples\": {d}\n", .{function.samples});
+            try writer.writeAll("    }");
+        }
+        try writer.writeAll("\n  ],\n  \"hotspots\": [\n");
+        for (self.hotspots, 0..) |hotspot, index| {
+            if (index != 0) try writer.writeAll(",\n");
+            try writer.writeAll("    {\n");
+            try writer.writeAll("      \"file\": ");
+            try output.writeJsonString(writer, hotspot.file);
+            try writer.print(",\n      \"line\": {d},\n", .{hotspot.line});
+            try writer.writeAll("      \"label\": ");
+            try output.writeJsonString(writer, hotspot.label);
+            try writer.print(",\n      \"self_pct\": {d:.1}\n", .{hotspot.self_pct});
+            try writer.writeAll("    }");
+        }
+        try writer.writeAll("\n  ]\n}\n");
+    }
+};


### PR DESCRIPTION
## Summary
- bootstrap the Zig CLI scaffold, shared artifact rendering, and backend seams
- add CPU profile and crash report schemas with text and JSON output
- implement a supervisor crash backend that captures child termination and stdio
- normalize crash artifacts for signals, non-zero exits, launch failures, and output overflows
- add crash command output-limit configuration and ignore Zig build artifacts in git

## Verification
- zig build
- zig build test
- zig build run -- crash --json --backend supervisor /bin/sh -- -c 'kill -SEGV $$'
- zig build run -- crash --json --backend supervisor /bin/sh -- -c 'exit 2'
- zig build run -- crash --json --backend supervisor /definitely/not/here
- zig build run -- crash --json --backend supervisor --max-output-bytes 10 /bin/sh -- -c 'printf 12345678901234567890'

Closes #1